### PR TITLE
Upgrade bcprov-jdk15on to version 1.66

### DIFF
--- a/fake-vulnerabilities-java-gradle/build.gradle
+++ b/fake-vulnerabilities-java-gradle/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     implementation 'commons-collections:commons-collections:3.2'
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.55'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.66'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/fake-vulnerabilities-java-maven/module-maven1/pom.xml
+++ b/fake-vulnerabilities-java-maven/module-maven1/pom.xml
@@ -21,5 +21,10 @@
             <artifactId>commons-collections</artifactId>
             <version>3.1</version>
         </dependency>
-    </dependencies>
+      <dependency>
+         <groupId>org.bouncycastle</groupId>
+         <artifactId>bcprov-jdk15on</artifactId>
+         <version>1.66</version>
+      </dependency>
+   </dependencies>
 </project>

--- a/fake-vulnerabilities-java-maven/module-maven2/pom.xml
+++ b/fake-vulnerabilities-java-maven/module-maven2/pom.xml
@@ -21,5 +21,10 @@
             <artifactId>commons-collections</artifactId>
             <version>3.2</version>
         </dependency>
-    </dependencies>
+      <dependency>
+         <groupId>org.bouncycastle</groupId>
+         <artifactId>bcprov-jdk15on</artifactId>
+         <version>1.66</version>
+      </dependency>
+   </dependencies>
 </project>

--- a/fake-vulnerabilities-java-maven/pom.xml
+++ b/fake-vulnerabilities-java-maven/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example.app</groupId>
@@ -26,7 +28,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.55</version>
+            <version>1.66</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades bcprov-jdk15on to 1.66 to fix vulnerabilities in current version